### PR TITLE
feat: add User-Agent header for SDK identification

### DIFF
--- a/src/util/visionFetch.ts
+++ b/src/util/visionFetch.ts
@@ -15,7 +15,7 @@ export const visionFetch = async (
       ...overrides?.headers,
       Authorization: config.getBasicAuth(),
       "x-api-key": config.apiKey,
-      "GLAIR-Vision-Nodejs-SDK-Version": "__packageVersion",
+      "User-Agent": "node:__packageVersion/GLAIR-Vision-SDK",
     },
     method: overrides?.method || "GET",
   };


### PR DESCRIPTION
## Overview

This pull request adds `User-Agent` header in all SDK request with the following format

```
node:<version>/GLAIR-Vision-SDK
```

This format will be standardized across SDKs.

### Build output

![Screenshot from 2023-11-17 14-15-35](https://github.com/glair-ai/glair-vision-node/assets/135583931/10f101ef-47e8-43cb-90ec-90d2b686c42b)
