### PR TITLE
chore(sdk): bump version to v0.1.0-beta.1 and update repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "planogram",
     "paperless"
   ],
-  "homepage": "https://github.com/glair-ai/glair-vision-node#readme",
+  "homepage": "https://github.com/GDP-ADMIN/glair-vision-node-sdk#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/glair-ai/glair-vision-node.git"
+    "url": "https://github.com/GDP-ADMIN/glair-vision-node-sdk.git"
   },
   "type": "module",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@glair/vision",
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "0.1.0-beta.1",
   "description": "GLAIR Vision Node.js SDK",
   "keywords": [
     "glair",


### PR DESCRIPTION
# Summary
* change version to 0.1.0-beta.1
* update the repository url to GDP-ADMIN/glair-vision-node-sdk

# How to test
none