### PR TITLE
feat: add BPKB param validation and page behavior to OCR service

### DIFF
--- a/src/api/ocr.test.ts
+++ b/src/api/ocr.test.ts
@@ -69,6 +69,44 @@ describe("Ocr", () => {
   });
 
   // ─────────────────────────────────────────────
+  // validateBPKBParam
+  // ─────────────────────────────────────────────
+  describe("validateBPKBParam", () => {
+    it("should return no errors when image is provided without page", () => {
+      const result = ocr.validateBPKBParam({ image: mockImage });
+      expect(result).toHaveLength(0);
+    });
+
+    it("should return no errors when page is within range (1)", () => {
+      const result = ocr.validateBPKBParam({ image: mockImage, page: 1 });
+      expect(result).toHaveLength(0);
+    });
+
+    it("should return no errors when page is within range (4)", () => {
+      const result = ocr.validateBPKBParam({ image: mockImage, page: 4 });
+      expect(result).toHaveLength(0);
+    });
+
+    it("should return an error when page is below range (0)", () => {
+      const result = ocr.validateBPKBParam({ image: mockImage, page: 0 });
+      expect(result).toHaveLength(1);
+      expect(result[0].message).toBe("Page must be between 1 and 4");
+    });
+
+    it("should return an error when page is above range (5)", () => {
+      const result = ocr.validateBPKBParam({ image: mockImage, page: 5 });
+      expect(result).toHaveLength(1);
+      expect(result[0].message).toBe("Page must be between 1 and 4");
+    });
+
+    it("should return image error when image is missing", () => {
+      const result = ocr.validateBPKBParam({ image: undefined as any });
+      expect(result).toHaveLength(1);
+      expect(result[0].message).toBe("Image is required");
+    });
+  });
+
+  // ─────────────────────────────────────────────
   // buildEndpoint (via fetchOCR behavior)
   // ─────────────────────────────────────────────
   describe("buildEndpoint", () => {
@@ -205,6 +243,36 @@ describe("Ocr", () => {
       await expect(
         (ocr[method] as Function)({ image: undefined })
       ).rejects.toThrow("Image is required");
+    });
+  });
+
+  // ─────────────────────────────────────────────
+  // BPKB-specific page behavior
+  // ─────────────────────────────────────────────
+  describe("bpkb page", () => {
+    it("should send page as a form field when provided", async () => {
+      const formDataSetSpy = vi.spyOn(FormData.prototype, "set");
+      await ocr.bpkb({ image: mockImage, page: 2 });
+      expect(formDataSetSpy).toHaveBeenCalledWith("page", "2");
+    });
+
+    it("should not send page as a form field when not provided", async () => {
+      const formDataSetSpy = vi.spyOn(FormData.prototype, "set");
+      await ocr.bpkb({ image: mockImage });
+      const pageCalls = formDataSetSpy.mock.calls.filter(
+        ([key]) => key === "page"
+      );
+      expect(pageCalls).toHaveLength(0);
+    });
+
+    it("should throw when page is out of range", async () => {
+      await expect(
+        ocr.bpkb({ image: mockImage, page: 0 } as any)
+      ).rejects.toThrow("Page must be between 1 and 4");
+
+      await expect(
+        ocr.bpkb({ image: mockImage, page: 5 } as any)
+      ).rejects.toThrow("Page must be between 1 and 4");
     });
   });
 });

--- a/src/api/ocr.test.ts
+++ b/src/api/ocr.test.ts
@@ -99,11 +99,11 @@ describe("Ocr", () => {
       );
     });
 
-    it("should NOT append /qualities for qualities endpoint even if qualities_detector is true", async () => {
-      await ocr.qualities({ image: mockImage, qualities_detector: true });
+    it("should ignore qualities_detector for non-KTP methods", async () => {
+      await (ocr.npwp as any)({ image: mockImage, qualities_detector: true });
       expect(mockVisionFetch).toHaveBeenCalledWith(
         mockConfigValue,
-        "ocr/:version/qualities",
+        "ocr/:version/npwp",
         expect.any(Object)
       );
     });

--- a/src/api/ocr.ts
+++ b/src/api/ocr.ts
@@ -4,7 +4,7 @@ import { KtpSessions } from "./sessions/ktpSessions";
 import { NPWPSessions } from "./sessions/npwpSessions";
 
 import { logInfo } from "../util/logger";
-import { isDefined, runSchemaValidation } from "../util/validator";
+import { isDefined, isNumberInRange, runSchemaValidation } from "../util/validator";
 import { visionFetch } from "../util/visionFetch";
 
 
@@ -36,6 +36,7 @@ import { getImageBlob } from "../util/image";
 
 type BaseOCRParam = { image: ImageSource };
 type OCRParam = BaseOCRParam & { qualities_detector?: boolean };
+type BPKBParam = BaseOCRParam & { page?: number };
 
 export class Ocr {
   readonly ktpSessions: KtpSessions;
@@ -66,9 +67,37 @@ export class Ocr {
     return this.fetchOCR<STNK>(param, "stnk", newConfig);
   }
 
-  async bpkb(param: BaseOCRParam, newConfig?: Partial<Settings>) {
+  async bpkb(param: BPKBParam, newConfig?: Partial<Settings>): Promise<BPKB> {
     logInfo("OCR - BPKB");
-    return this.fetchOCR<BPKB>(param, "bpkb", newConfig);
+    const validationResult = this.validateBPKBParam(param);
+    if (validationResult.length) {
+      throw new Error(validationResult[0].message);
+    }
+
+    const { image } = param;
+
+    const formData = new FormData();
+    formData.set(
+      "image",
+      await getImageBlob(image),
+      "filename.jpg"
+    );
+
+    if (param.page !== undefined) {
+      formData.set("page", String(param.page));
+    }
+
+    const req = {
+      method: "POST",
+      body: formData,
+    };
+
+    const config = this.config.getConfig(newConfig);
+    return visionFetch(
+      config,
+      this.buildEndpoint("bpkb"),
+      req
+    );
   }
 
   async passport(param: BaseOCRParam, newConfig?: Partial<Settings>) {
@@ -215,5 +244,16 @@ export class Ocr {
     };
 
     return runSchemaValidation(param, schema);
+  }
+
+  validateBPKBParam(param: BPKBParam) {
+    const errors = this.validateOCRParam(param);
+    if (errors.length) return errors;
+
+    if (param.page !== undefined && !isNumberInRange(param.page, 1, 4)) {
+      return [{ key: "page", message: "Page must be between 1 and 4" }];
+    }
+
+    return [];
   }
 }

--- a/src/api/ocr.ts
+++ b/src/api/ocr.ts
@@ -34,7 +34,8 @@ import type { Transcript } from "../types/transcript";
 import { ImageSource } from "../types/image";
 import { getImageBlob } from "../util/image";
 
-type OCRParam = { image: ImageSource; qualities_detector?: boolean };
+type BaseOCRParam = { image: ImageSource };
+type OCRParam = BaseOCRParam & { qualities_detector?: boolean };
 
 export class Ocr {
   readonly ktpSessions: KtpSessions;
@@ -47,60 +48,60 @@ export class Ocr {
 
   async ktp(param: OCRParam, newConfig?: Partial<Settings>) {
     logInfo("OCR - KTP");
-    return this.fetchOCR<KTP>(param, "ktp", newConfig);
+    return this.fetchOCR<KTP>(param, "ktp", newConfig, param.qualities_detector);
   }
 
-  async npwp(param: OCRParam, newConfig?: Partial<Settings>) {
+  async npwp(param: BaseOCRParam, newConfig?: Partial<Settings>) {
     logInfo("OCR - NPWP");
     return this.fetchOCR<NPWP>(param, "npwp", newConfig);
   }
 
-  async kk(param: OCRParam, newConfig?: Partial<Settings>) {
+  async kk(param: BaseOCRParam, newConfig?: Partial<Settings>) {
     logInfo("OCR - KK");
     return this.fetchOCR<KK>(param, "kk", newConfig);
   }
 
-  async stnk(param: OCRParam, newConfig?: Partial<Settings>) {
+  async stnk(param: BaseOCRParam, newConfig?: Partial<Settings>) {
     logInfo("OCR - STNK");
     return this.fetchOCR<STNK>(param, "stnk", newConfig);
   }
 
-  async bpkb(param: OCRParam, newConfig?: Partial<Settings>) {
+  async bpkb(param: BaseOCRParam, newConfig?: Partial<Settings>) {
     logInfo("OCR - BPKB");
     return this.fetchOCR<BPKB>(param, "bpkb", newConfig);
   }
 
-  async passport(param: OCRParam, newConfig?: Partial<Settings>) {
+  async passport(param: BaseOCRParam, newConfig?: Partial<Settings>) {
     logInfo("OCR - Passport");
     return this.fetchOCR<Passport>(param, "passport", newConfig);
   }
 
-  async licensePlate(param: OCRParam, newConfig?: Partial<Settings>) {
+  async licensePlate(param: BaseOCRParam, newConfig?: Partial<Settings>) {
     logInfo("OCR - License Plate");
     return this.fetchOCR<Plate>(param, "plate", newConfig);
   }
 
-  async generalDocument(param: OCRParam, newConfig?: Partial<Settings>) {
+  async generalDocument(param: BaseOCRParam, newConfig?: Partial<Settings>) {
     logInfo("OCR - General Document");
     return this.fetchOCR<GeneralDocument>(param, "general-document", newConfig);
   }
 
-  async invoice(param: OCRParam, newConfig?: Partial<Settings>) {
+  async invoice(param: BaseOCRParam, newConfig?: Partial<Settings>) {
     logInfo("OCR - Invoice");
     return this.fetchOCR<Invoice>(param, "invoice", newConfig);
   }
 
-  async receipt(param: OCRParam, newConfig?: Partial<Settings>) {
+  async receipt(param: BaseOCRParam, newConfig?: Partial<Settings>) {
     logInfo("OCR - Receipt");
     return this.fetchOCR<Receipt>(param, "receipt", newConfig);
   }
 
-  async singaporeNRIC(param: OCRParam, newConfig?: Partial<Settings>) {
+  async singaporeNRIC(param: BaseOCRParam, newConfig?: Partial<Settings>) {
     logInfo("OCR - Singapore NRIC");
     return this.fetchOCR<SingaporeNRIC>(param, "singapore-nric", newConfig);
   }
 
-  async singaporeFamilyPass(param: OCRParam, newConfig?: Partial<Settings>) {
+  async singaporeFamilyPass(param: BaseOCRParam, newConfig?: Partial<Settings>) {
     logInfo("OCR - Singapore Family Pass");
     return this.fetchOCR<SingaporeFamilyPass>(
       param,
@@ -109,7 +110,7 @@ export class Ocr {
     );
   }
 
-  async singaporeWorkPermit(param: OCRParam, newConfig?: Partial<Settings>) {
+  async singaporeWorkPermit(param: BaseOCRParam, newConfig?: Partial<Settings>) {
     logInfo("OCR - Singapore Work Permit");
     return this.fetchOCR<SingaporeWorkPermit>(
       param,
@@ -118,67 +119,68 @@ export class Ocr {
     );
   }
 
-    async sim(param: OCRParam, newConfig?: Partial<Settings>) {
+    async sim(param: BaseOCRParam, newConfig?: Partial<Settings>) {
     logInfo("OCR - SIM");
     return this.fetchOCR<SIM>(param,"sim",newConfig);
   }
 
-  async bankStatement(param: OCRParam, newConfig?: Partial<Settings>) {
+  async bankStatement(param: BaseOCRParam, newConfig?: Partial<Settings>) {
     logInfo("OCR - Bank Statement");
     return this.fetchOCR<BankStatement>(param, "bank-statement", newConfig);
   }
 
-  async bstk(param: OCRParam, newConfig?: Partial<Settings>) {
+  async bstk(param: BaseOCRParam, newConfig?: Partial<Settings>) {
     logInfo("OCR - BSTK");
     return this.fetchOCR<BSTK>(param, "bstk", newConfig);
   }
 
-  async diploma(param: OCRParam, newConfig?: Partial<Settings>) {
+  async diploma(param: BaseOCRParam, newConfig?: Partial<Settings>) {
     logInfo("OCR - Diploma");
     return this.fetchOCR<Diploma>(param, "diploma", newConfig);
   }
 
-  async financialStatement(param: OCRParam, newConfig?: Partial<Settings>) {
+  async financialStatement(param: BaseOCRParam, newConfig?: Partial<Settings>) {
     logInfo("OCR - Financial Statement");
     return this.fetchOCR<FinancialStatement>(param, "financial-statement", newConfig);
   }
 
-  async kitasKitap(param: OCRParam, newConfig?: Partial<Settings>) {
+  async kitasKitap(param: BaseOCRParam, newConfig?: Partial<Settings>) {
     logInfo("OCR - KITAS/KITAP");
     return this.fetchOCR<KitasKitap>(param, "kitas-kitap", newConfig);
   }
 
-  async phonePackaging(param: OCRParam, newConfig?: Partial<Settings>) {
+  async phonePackaging(param: BaseOCRParam, newConfig?: Partial<Settings>) {
     logInfo("OCR - Phone Packaging");
     return this.fetchOCR<PhonePackaging>(param, "phone-packaging", newConfig);
   }
 
-  async qualities(param: OCRParam, newConfig?: Partial<Settings>) {
+  async qualities(param: BaseOCRParam, newConfig?: Partial<Settings>) {
     logInfo("OCR - Qualities");
     return this.fetchOCR<Qualities>(param, "qualities", newConfig);
   }
 
-  async taxInvoice(param: OCRParam, newConfig?: Partial<Settings>) {
+  async taxInvoice(param: BaseOCRParam, newConfig?: Partial<Settings>) {
     logInfo("OCR - Tax Invoice");
     return this.fetchOCR<TaxInvoice>(param, "tax-invoice", newConfig);
   }
 
-  async transcript(param: OCRParam, newConfig?: Partial<Settings>) {
+  async transcript(param: BaseOCRParam, newConfig?: Partial<Settings>) {
     logInfo("OCR - Transcript");
     return this.fetchOCR<Transcript>(param, "transcript", newConfig);
   }
 
   private async fetchOCR<T>(
-    param: OCRParam,
+    param: BaseOCRParam,
     endpoint: string,
-    newConfig?: Partial<Settings>
+    newConfig?: Partial<Settings>,
+    qualities_detector = false
   ): Promise<T> {
     const validationResult = this.validateOCRParam(param);
     if (validationResult.length) {
       throw new Error(validationResult[0].message);
     }
 
-    const { image, qualities_detector } = param;
+    const { image } = param;
 
     const formData = new FormData();
     formData.set(
@@ -200,14 +202,14 @@ export class Ocr {
     );
   }
 
-  private buildEndpoint(endpoint: string, qualities_detector?: boolean): string {
-    if (!qualities_detector || endpoint === "qualities") {
+  private buildEndpoint(endpoint: string, qualities_detector = false): string {
+    if (!qualities_detector) {
       return `ocr/:version/${endpoint}`;
     }
     return `ocr/:version/${endpoint}/qualities`;
   }
 
-  validateOCRParam(param: OCRParam) {
+  validateOCRParam(param: BaseOCRParam) {
     const schema = {
       image: (val: any) => (isDefined(val) ? "" : "Image is required"),
     };

--- a/src/util/validator.test.ts
+++ b/src/util/validator.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { isDefined, isValidURL, runSchemaValidation } from "./validator";
+import { isDefined, isNumberInRange, isValidURL, runSchemaValidation } from "./validator";
 
 describe("isValidURL", () => {
   test("should return false", () => {
@@ -47,6 +47,38 @@ describe("isString", () => {
     const input = new String("test_string");
 
     expect(isDefined(input)).toBe(true);
+  });
+});
+
+describe("isNumberInRange", () => {
+  test("should return true for value within range", () => {
+    expect(isNumberInRange(2, 1, 4)).toBe(true);
+  });
+
+  test("should return true for min boundary", () => {
+    expect(isNumberInRange(1, 1, 4)).toBe(true);
+  });
+
+  test("should return true for max boundary", () => {
+    expect(isNumberInRange(4, 1, 4)).toBe(true);
+  });
+
+  test("should return false for value below min", () => {
+    expect(isNumberInRange(0, 1, 4)).toBe(false);
+  });
+
+  test("should return false for value above max", () => {
+    expect(isNumberInRange(5, 1, 4)).toBe(false);
+  });
+
+  test("should return false for NaN", () => {
+    expect(isNumberInRange(NaN, 1, 4)).toBe(false);
+  });
+
+  test("should return false for non-number types", () => {
+    expect(isNumberInRange("2", 1, 4)).toBe(false);
+    expect(isNumberInRange(undefined, 1, 4)).toBe(false);
+    expect(isNumberInRange(null, 1, 4)).toBe(false);
   });
 });
 

--- a/src/util/validator.ts
+++ b/src/util/validator.ts
@@ -17,6 +17,10 @@ export function isString(val: unknown) {
   return typeof val === "string";
 }
 
+export function isNumberInRange(val: unknown, min: number, max: number) {
+  return typeof val === "number" && !isNaN(val) && val >= min && val <= max;
+}
+
 export function runSchemaValidation(
   obj: Record<string, any>,
   schema: Record<string, (val: any) => string>


### PR DESCRIPTION
# feat: add BPKB param validation and page behavior to OCR service

## Summary

This PR refactors the OCR service by splitting the input parameters into a generic `BaseOCRParam` and endpoint-specific parameters. It adds `BPKB`-specific validation along with custom `FormData` payload mapping for the page attribute , while cleaning up unnecessary parameter exposures for non-KTP endpoints.

## How to Test

1. Run the OCR unit tests using `vitest`: `npm test src/api/ocr.test.ts` 


2. Run the validator unit tests: `npm test src/util/validator.test.ts` 


3. Expected result: All tests pass, including the new boundary checks for `isNumberInRange` and parameter validation schemas for `validateBPKBParam`.



## Related Issues

None

## Author Checklist

* [x] Code follows team coding standards and style guide
* [x] Self-reviewed the code changes
* [x] Added/updated tests for new functionality
* [x] All tests pass locally
* [x] Code is properly documented
* [x] Synced with latest develop branch
* [x] PR title follows conventional commit format
* [x] Meaningful commit messages used
* [ ] Add AI Feedback Author comment **(after merge)**
AI Feedback: Author
[numbering] TP/FP | (Impact) Suggestion | author notes
model-[number]: model-1 (for development)
prompt-[number]: (development-prompt)

## Reviewer Checklist

* [ ] First reviewer should comment START REVIEW before reviewing, **once per PR**
* [ ] Add AI Feedback Reviewer comment, **once per Reviewer**
AI Feedback: Reviewer
model: model-1, model-2, ... (for review)
prompt: (review-prompt)
caught by reviewer: 

## Additional Notes

1. [[GDP Labs Coding and Code Review Best Practices](https://docs.google.com/document/d/1QCzqnxXPEN_fatbTaSt-LVL9vFKoEBrQ6zTCt3tbCWU/edit)](https://docs.google.com/document/d/1QCzqnxXPEN_fatbTaSt-LVL9vFKoEBrQ6zTCt3tbCWU/edit)
2. 
`bpkb` requests no longer share the unified `fetchOCR` execution pathway, breaking away to handle manual multi-part payload assembly in order to bind the optional `page` parameter.